### PR TITLE
Don't follow redirect

### DIFF
--- a/src/Message/ProcessPaymentRequest.php
+++ b/src/Message/ProcessPaymentRequest.php
@@ -51,9 +51,9 @@ class ProcessPaymentRequest extends AbstractRequest
         $httpRequest = $this->httpClient->get(
             $url,
             null,
-            [
+            array(
                 RequestOptions::ALLOW_REDIRECTS => false,
-            ]
+            )
         );
 
         $httpResponse = $httpRequest->send();

--- a/src/Message/ProcessPaymentRequest.php
+++ b/src/Message/ProcessPaymentRequest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Csob\Message;
 
 use Guzzle\Http\Message\RequestInterface;
+use GuzzleHttp\RequestOptions;
 
 class ProcessPaymentRequest extends AbstractRequest
 {
@@ -46,9 +47,13 @@ class ProcessPaymentRequest extends AbstractRequest
      */
     public function sendData($data)
     {
-        $httpRequest = $this->httpClient->createRequest(
-            RequestInterface::GET,
-            $this->createUri()
+        $url = $this->createUri();
+        $httpRequest = $this->httpClient->get(
+            $url,
+            null,
+            [
+                RequestOptions::ALLOW_REDIRECTS => false,
+            ]
         );
 
         $httpResponse = $httpRequest->send();


### PR DESCRIPTION
CSOB checks if IP address is the same. Following redirect would cause server is the first visitor and then client access is denied
