### PR TITLE
Support any storage for keys

### DIFF
--- a/src/GatewayFactory.php
+++ b/src/GatewayFactory.php
@@ -12,16 +12,16 @@ use Omnipay\Omnipay;
 class GatewayFactory
 {
     /**
-     * @param string $publicKeyFilename
-     * @param string $privateKeyFilename
+     * @param string $publicKey Content of the file
+     * @param string $privateKey Content of the file
      * @param string $privateKeyPassword
      * @return Gateway
      */
-    public static function createInstance($publicKeyFilename, $privateKeyFilename, $privateKeyPassword = null)
+    public static function createInstance($publicKey, $privateKey, $privateKeyPassword = null)
     {
         $preparer = new Preparer();
-        $signator = new Signator($privateKeyFilename, $privateKeyPassword);
-        $verifier = new Verifier($publicKeyFilename);
+        $signator = new Signator($privateKey, $privateKeyPassword);
+        $verifier = new Verifier($publicKey);
         $dataSignator = new DataSignator($preparer, $signator);
         $dataVerifier = new DataVerifier($preparer, $verifier);
 

--- a/src/Sign/Signator.php
+++ b/src/Sign/Signator.php
@@ -5,14 +5,18 @@ namespace Omnipay\Csob\Sign;
 class Signator
 {
     /** @var string */
-    private $privateKeyFilename;
+    private $privateKey;
 
     /** @var string */
     private $privateKeyPassword;
 
-    function __construct($privateKeyFilename, $privateKeyPassword = null)
+    /**
+     * @param string $privateKey Content of private key file
+     * @param string $privateKeyPassword
+     */
+    function __construct($privateKey, $privateKeyPassword = null)
     {
-        $this->privateKeyFilename = $privateKeyFilename;
+        $this->privateKey = $privateKey;
         $this->privateKeyPassword = $privateKeyPassword;
     }
 
@@ -21,8 +25,7 @@ class Signator
      * @return string Base64 encoded
      */
     public function sign($text) {
-        $private = file_get_contents($this->privateKeyFilename);
-        $privateKeyId = openssl_get_privatekey($private, $this->privateKeyPassword);
+        $privateKeyId = openssl_get_privatekey($this->privateKey, $this->privateKeyPassword);
 
         openssl_sign($text, $signature, $privateKeyId);
         $signature = base64_encode($signature);

--- a/src/Sign/Verifier.php
+++ b/src/Sign/Verifier.php
@@ -5,11 +5,14 @@ namespace Omnipay\Csob\Sign;
 class Verifier
 {
     /** @var string */
-    private $publicKeyFilename;
+    private $publicKey;
 
-    function __construct($publicKeyFilename)
+    /**
+     * @param string $publicKey Content of public key file
+     */
+    function __construct($publicKey)
     {
-        $this->publicKeyFilename = $publicKeyFilename;
+        $this->publicKey = $publicKey;
     }
 
     /**
@@ -18,8 +21,7 @@ class Verifier
      * @return bool
      */
     function verify($text, $signatureBase64) {
-        $public = file_get_contents($this->publicKeyFilename);
-        $publicKeyId = openssl_get_publickey($public);
+        $publicKeyId = openssl_get_publickey($this->publicKey);
 
         $signature = base64_decode($signatureBase64);
         $res = openssl_verify($text, $signature, $publicKeyId);

--- a/tests/unit/Sign/DataSignatorTest.php
+++ b/tests/unit/Sign/DataSignatorTest.php
@@ -4,7 +4,7 @@ class DataSignatorTest extends PHPUnit_Framework_TestCase {
 
     public function testSign()
     {
-        $privateKey = __DIR__ . '/assets/rsa_A1029DTmM7.key';
+        $privateKey = file_get_contents(__DIR__ . '/assets/rsa_A1029DTmM7.key');
         $publicKey = file_get_contents(__DIR__ . '/assets/rsa_A1029DTmM7.pub');
         $preparer = new \Omnipay\Csob\Sign\Preparer();
         $signator = new \Omnipay\Csob\Sign\Signator($privateKey);

--- a/tests/unit/Sign/DataSignatorTest.php
+++ b/tests/unit/Sign/DataSignatorTest.php
@@ -5,7 +5,7 @@ class DataSignatorTest extends PHPUnit_Framework_TestCase {
     public function testSign()
     {
         $privateKey = __DIR__ . '/assets/rsa_A1029DTmM7.key';
-        $publicKey = __DIR__ . '/assets/rsa_A1029DTmM7.pub';
+        $publicKey = file_get_contents(__DIR__ . '/assets/rsa_A1029DTmM7.pub');
         $preparer = new \Omnipay\Csob\Sign\Preparer();
         $signator = new \Omnipay\Csob\Sign\Signator($privateKey);
         $verifier = new \Omnipay\Csob\Sign\Verifier($publicKey);

--- a/tests/unit/Sign/DataVerifierTest.php
+++ b/tests/unit/Sign/DataVerifierTest.php
@@ -4,7 +4,7 @@ class DataVerifierTest extends PHPUnit_Framework_TestCase
 {
     public function testVerify()
     {
-        $publicKey = __DIR__ . '/assets/mips_iplatebnibrana.csob.cz.pub';
+        $publicKey = file_get_contents(__DIR__ . '/assets/mips_iplatebnibrana.csob.cz.pub');
         $preparer = new \Omnipay\Csob\Sign\Preparer();
         $verifier = new \Omnipay\Csob\Sign\Verifier($publicKey);
         $dataVerifier = new \Omnipay\Csob\Sign\DataVerifier($preparer, $verifier);

--- a/tests/unit/Sign/SignatorTest.php
+++ b/tests/unit/Sign/SignatorTest.php
@@ -4,7 +4,7 @@ class SignatorTest extends PHPUnit_Framework_TestCase
 {
     public function testSign()
     {
-        $privateKey = __DIR__ . '/assets/rsa_A1029DTmM7.key';
+        $privateKey = file_get_contents(__DIR__ . '/assets/rsa_A1029DTmM7.key');
         $publicKey = file_get_contents(__DIR__ . '/assets/rsa_A1029DTmM7.pub');
         $signator = new \Omnipay\Csob\Sign\Signator($privateKey);
         $verifier = new \Omnipay\Csob\Sign\Verifier($publicKey);

--- a/tests/unit/Sign/SignatorTest.php
+++ b/tests/unit/Sign/SignatorTest.php
@@ -5,7 +5,7 @@ class SignatorTest extends PHPUnit_Framework_TestCase
     public function testSign()
     {
         $privateKey = __DIR__ . '/assets/rsa_A1029DTmM7.key';
-        $publicKey = __DIR__ . '/assets/rsa_A1029DTmM7.pub';
+        $publicKey = file_get_contents(__DIR__ . '/assets/rsa_A1029DTmM7.pub');
         $signator = new \Omnipay\Csob\Sign\Signator($privateKey);
         $verifier = new \Omnipay\Csob\Sign\Verifier($publicKey);
         $text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec malesuada porta orci, eget vehicula tortor eleifend in.';

--- a/tests/unit/Sign/VerifierTest.php
+++ b/tests/unit/Sign/VerifierTest.php
@@ -4,7 +4,7 @@ class VerifierTest extends PHPUnit_Framework_TestCase
 {
     public function testVerify()
     {
-        $privateKey = __DIR__ . '/assets/rsa_A1029DTmM7.key';
+        $privateKey = file_get_contents(__DIR__ . '/assets/rsa_A1029DTmM7.key');
         $publicKey = file_get_contents(__DIR__ . '/assets/rsa_A1029DTmM7.pub');
         $signator = new \Omnipay\Csob\Sign\Signator($privateKey);
         $verifier = new \Omnipay\Csob\Sign\Verifier($publicKey);

--- a/tests/unit/Sign/VerifierTest.php
+++ b/tests/unit/Sign/VerifierTest.php
@@ -5,7 +5,7 @@ class VerifierTest extends PHPUnit_Framework_TestCase
     public function testVerify()
     {
         $privateKey = __DIR__ . '/assets/rsa_A1029DTmM7.key';
-        $publicKey = __DIR__ . '/assets/rsa_A1029DTmM7.pub';
+        $publicKey = file_get_contents(__DIR__ . '/assets/rsa_A1029DTmM7.pub');
         $signator = new \Omnipay\Csob\Sign\Signator($privateKey);
         $verifier = new \Omnipay\Csob\Sign\Verifier($publicKey);
         $text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas metus arcu, accumsan in massa non';


### PR DESCRIPTION
Constructors now accepts only the content of keys not the file path. It's creator responsibility to get the content and due to that the keys can be stored anywhere (e.g. S3)
